### PR TITLE
Refactor JSON helpers into shared utils

### DIFF
--- a/alvys_insert.py
+++ b/alvys_insert.py
@@ -1,11 +1,11 @@
 import os
-import json
 import pandas as pd
 import sys
 import time
 from datetime import datetime
 from typing import List, Dict
 from dotenv import load_dotenv # type: ignore
+from utils.io import load_json, safe_datetime
 
 load_dotenv()
 
@@ -13,25 +13,6 @@ import db
 DATA_DIR = "alvys_weekly_data"
 BATCH_SIZE = 500
 # Database connection handled via db.get_conn()
-
-
-def load_json(filename: str) -> List[Dict]:
-    with open(os.path.join(DATA_DIR, filename), encoding="utf-8") as f:
-        return json.load(f)
-
-def safe_datetime(val):
-    if not val:
-        return None
-    s = val.replace("Z", "+00:00")
-    if "." in s and "+" in s:
-        prefix, rest = s.split(".", 1)
-        frac, offset = rest.split("+", 1)
-        frac6 = frac[:6].ljust(6, "0")
-        s = f"{prefix}.{frac6}+{offset}"
-    try:
-        return datetime.fromisoformat(s)
-    except Exception:
-        return None
 
 
 def sanitize_driver(d: Dict) -> Dict:
@@ -141,27 +122,39 @@ def main():
 
     if run_all or "trailers" in args:
         print("Loading trailers JSON...")
-        trailers = [sanitize_trailer(t) for t in load_json("TRAILERS.json")]
+        trailers = [
+            sanitize_trailer(t)
+            for t in load_json(os.path.join(DATA_DIR, "TRAILERS.json"))
+        ]
         batch_insert("ALVYS_TRAILERS_RAW", trailers, conn)
 
     if run_all or "trucks" in args:
         print("Loading trucks JSON...")
-        trucks = [sanitize_truck(t) for t in load_json("TRUCKS.json")]
+        trucks = [
+            sanitize_truck(t)
+            for t in load_json(os.path.join(DATA_DIR, "TRUCKS.json"))
+        ]
         batch_insert("ALVYS_TRUCKS_RAW", trucks, conn)
 
     if run_all or "drivers" in args:
         print("Loading drivers JSON...")
-        drivers = [sanitize_driver(d) for d in load_json("DRIVERS.json")]
+        drivers = [
+            sanitize_driver(d)
+            for d in load_json(os.path.join(DATA_DIR, "DRIVERS.json"))
+        ]
         batch_insert("ALVYS_DRIVERS_RAW", drivers, conn)
 
     if run_all or "customers" in args:
         print("Loading customers JSON...")
-        customers = [sanitize_customer(c) for c in load_json("CUSTOMERS.json")]
+        customers = [
+            sanitize_customer(c)
+            for c in load_json(os.path.join(DATA_DIR, "CUSTOMERS.json"))
+        ]
         batch_insert("ALVYS_CUSTOMERS_RAW", customers, conn)
 
     if run_all or "carriers" in args:
         print("Loading carriers JSON...")
-        raw = load_json("CARRIERS.json")
+        raw = load_json(os.path.join(DATA_DIR, "CARRIERS.json"))
         items = raw.get("Items") if isinstance(raw, dict) else raw
         carriers = [sanitize_carrier(c) for c in items]
         batch_insert("ALVYS_CARRIERS_RAW", carriers, conn)

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""I/O helpers for the Alvys ingestion pipeline."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+
+def load_json(path: str) -> list[dict]:
+    """Read a JSON file and return the parsed object."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def safe_datetime(val: str | None) -> datetime | None:
+    """Parse ISO-8601 datetime strings into :class:`datetime` objects.
+
+    Returns ``None`` for falsy values or parsing errors.
+    """
+    if not val:
+        return None
+    s = val.replace("Z", "+00:00")
+    if "." in s and "+" in s:
+        prefix, rest = s.split(".", 1)
+        frac, offset = rest.split("+", 1)
+        frac6 = frac[:6].ljust(6, "0")
+        s = f"{prefix}.{frac6}+{offset}"
+    try:
+        return datetime.fromisoformat(s)
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- add utils.io module with load_json and safe_datetime helpers
- refactor alvys_insert.py and active_entities_insert.py to use shared utilities
- update load_json calls to pass explicit paths

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68a7900425b08333845b74eb305144cc