### PR TITLE
refactor: remove legacy SQL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,9 @@ ALVYS_CLIENT_ID="value"
 ALVYS_CLIENT_SECRET="value"
 ALVYS_GRANT_TYPE="value"
 
-# SQL Server (used by ingestion scripts)
-SQL_SERVER="value"
-SQL_DATABASE="value"
-SQL_USERNAME="value"
-SQL_PASSWORD="value"
+# SQL Server connection string
+ALVYS_SQL_CONN_STR="DRIVER={ODBC Driver 17 for SQL Server};SERVER=server;DATABASE=db;UID=user;PWD=pwd"
 ```
-
-The config module constructs the SQL Server connection string from the four
-variables above; no separate `ALVYS_SQL_CONN_STR` is needed.
 
 Place a copy of this file at the project root as `.env` and fill in the real
 values for your environment.

--- a/config.py
+++ b/config.py
@@ -17,13 +17,12 @@ from typing import Dict
 from dotenv import load_dotenv  # type: ignore
 import pyodbc
 
+from db import get_conn
+
 load_dotenv()
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-# Name of the environment variable holding the full SQL Server connection str
-_CONN_ENV = "ALVYS_SQL_CONN_STR"
-
 # Table and columns that map SCAC -> auth credentials
 _TABLE = "dbo.ALVYS_CLIENTS"
 _COLS = ["TENANT_ID", "CLIENT_ID", "CLIENT_SECRET", "GRANT_TYPE"]
@@ -34,25 +33,8 @@ _COLS = ["TENANT_ID", "CLIENT_ID", "CLIENT_SECRET", "GRANT_TYPE"]
 # ---------------------------------------------------------------------------
 
 def _get_sql_connection() -> pyodbc.Connection:
-    """Return a live pyodbc connection using the env-defined conn string."""
-    conn_str = os.getenv(_CONN_ENV)
-    if not conn_str:
-        server = os.getenv("SQL_SERVER")
-        db = os.getenv("SQL_DATABASE")
-        user = os.getenv("SQL_USERNAME")
-        pwd = os.getenv("SQL_PASSWORD")
-        if not all([server, db, user, pwd]):
-            raise RuntimeError(
-                "Environment variables 'SQL_SERVER', 'SQL_DATABASE',"
-                " 'SQL_USERNAME', and 'SQL_PASSWORD' must be set with the "
-                "SQL Server connection details before running the pipeline."
-            )
-        conn_str = (
-            f"DRIVER={{ODBC Driver 17 for SQL Server}};SERVER={server};"
-            f"DATABASE={db};UID={user};PWD={pwd}"
-        )
-    # autocommit=False so callers can control transaction scope (BEGIN/ROLLBACK)
-    return pyodbc.connect(conn_str, autocommit=False, timeout=30)
+    """Return a live ``pyodbc`` connection using ``ALVYS_SQL_CONN_STR``."""
+    return get_conn()
 
 
 # ---------------------------------------------------------------------------

--- a/dev.example.env
+++ b/dev.example.env
@@ -4,8 +4,5 @@ ALVYS_CLIENT_ID="value"
 ALVYS_CLIENT_SECRET="value"
 ALVYS_GRANT_TYPE="value"
 
-# SQL Server (used by ingestion scripts)
-SQL_SERVER="value"
-SQL_DATABASE="value"
-SQL_USERNAME="value"
-SQL_PASSWORD="value"
+# SQL Server connection string
+ALVYS_SQL_CONN_STR="DRIVER={ODBC Driver 17 for SQL Server};SERVER=server;DATABASE=db;UID=user;PWD=pwd"


### PR DESCRIPTION
## Summary
- drop SQL_SERVER/SQL_DATABASE/SQL_USERNAME/SQL_PASSWORD usage in favor of ALVYS_SQL_CONN_STR
- document ALVYS_SQL_CONN_STR in README and env example

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py config.py db.py`


------
https://chatgpt.com/codex/tasks/task_b_68a79501021c833395f8da7cc77ccf27