### PR TITLE
Parameterize insert schemas

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,15 +132,11 @@ def run_export(scac: str, entities: List[str], weeks_ago: int, dry_run: bool) ->
 # --------------------------------------------
 
 def run_insert(scac: str, entities: List[str], dry_run: bool) -> None:
-    if dry_run:
-        print("[DRY-RUN] Would insert:", entities, "into schema", scac)
-        return
-
     schema = scac.upper()
 
-    # Provide schema override to the shared loader
-    if hasattr(aei, "SCHEMA"):
-        aei.SCHEMA = schema
+    if dry_run:
+        print("[DRY-RUN] Would insert:", entities, "into schema", schema)
+        return
 
     for ent in entities:
         # 1)  Route active entities to active_entities_insert.py
@@ -148,7 +144,7 @@ def run_insert(scac: str, entities: List[str], dry_run: bool) -> None:
             print(f"-> inserting {ent.upper()} ...")
             _orig = sys.argv  # preserve caller args
             try:
-                sys.argv = ["active_entities_insert.py", ent]
+                sys.argv = ["active_entities_insert.py", ent, "--scac", scac]
                 aei.main()
             finally:
                 sys.argv = _orig


### PR DESCRIPTION
## Summary
- Accept `--scac` schema flag in all insert scripts and build table names at runtime
- Invoke insert modules with client schema from `main.run_insert`
- Route active entity inserts using provided schema

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py inserts/loads_insert.py inserts/trips_insert.py inserts/invoices_insert.py main.py`
- `python main.py insert loads --scac TBXX` *(fails: Environment variable 'ALVYS_SQL_CONN_STR' is not set)*

------
https://chatgpt.com/codex/tasks/task_b_68a88eb6002c833390349cac2340805c