### PR TITLE
feat: isolate weekly exports by client

### DIFF
--- a/alvys_export.py
+++ b/alvys_export.py
@@ -349,6 +349,8 @@ def cli_run(argv: List[str]) -> None:
     """
     args = [a.lower() for a in argv]
     run_all = len(args) == 0
+    scac = os.getenv("ALVYS_SCAC", "").upper() or "UNKNOWN"
+    out_dir = Path(OUTPUT_DIR) / scac
 
     token = get_token()
     headers = {
@@ -407,7 +409,7 @@ def cli_run(argv: List[str]) -> None:
                 for rec in data:
                     rec["FILE_ID"] = file_id
                 fname = f"{name.upper()}_API_{format_range(start, end)}.json"
-                save_json(data, fname)
+                save_json(data, fname, out_dir)
                 log("OK", name.upper(), "done")
             except Exception as exc:
                 log(
@@ -454,7 +456,7 @@ def cli_run(argv: List[str]) -> None:
             file_id = get_file_id()
             for rec in data:
                 rec["FILE_ID"] = file_id
-            save_json(data, f"{name.upper()}.json")
+            save_json(data, f"{name.upper()}.json", out_dir)
             log("OK", name.upper(), "done")
         except Exception as exc:
             log(

--- a/ingest_client/__init__.py
+++ b/ingest_client/__init__.py
@@ -2,14 +2,16 @@
 
 import logging
 import os
-from typing import Dict
+from pathlib import Path
+from typing import Dict, Any
 
-from main import ENTITIES, run_export, run_insert
+from main import ENTITIES, DATA_DIR, run_export, run_insert
 
 
-def main(params: Dict[str, Dict[str, str]]) -> str:
+def main(params: Dict[str, Any]) -> str:
     scac = params["scac"]
     creds = params["credentials"]
+    data_dir = Path(params.get("data_dir") or (DATA_DIR / scac.upper()))
 
     os.environ["ALVYS_TENANT_ID"] = creds["tenant_id"]
     os.environ["ALVYS_CLIENT_ID"] = creds["client_id"]
@@ -17,7 +19,7 @@ def main(params: Dict[str, Dict[str, str]]) -> str:
     os.environ["ALVYS_GRANT_TYPE"] = creds["grant_type"]
 
     logging.info("Processing %s", scac)
-    run_export(scac, ENTITIES, weeks_ago=0, dry_run=False)
+    run_export(scac, ENTITIES, weeks_ago=0, dry_run=False, output_dir=data_dir)
     run_insert(scac, ENTITIES, dry_run=False)
     return scac
 


### PR DESCRIPTION
## Summary
- write exports into `alvys_weekly_data/{SCAC}` and plumb that path through the exporter
- propagate SCAC-aware paths through weekly ingest and CLI runners
- allow legacy `alvys_export` CLI to honor `ALVYS_SCAC`

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement azure-functions-durable)*
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py`
- `python -m py_compile ingest_client/__init__.py weekly_ingest/__init__.py`

------
https://chatgpt.com/codex/tasks/task_b_68a899c6bd2c8333bdf670914ecaccb8