### PR TITLE
Parameterize insert scripts with data directory

### DIFF
--- a/ingest_client/__init__.py
+++ b/ingest_client/__init__.py
@@ -20,6 +20,6 @@ def main(params: Dict[str, Any]) -> str:
 
     logging.info("Processing %s", scac)
     run_export(scac, ENTITIES, weeks_ago=0, dry_run=False, output_dir=data_dir)
-    run_insert(scac, ENTITIES, dry_run=False)
+    run_insert(scac, ENTITIES, dry_run=False, data_dir=data_dir)
     return scac
 


### PR DESCRIPTION
## Summary
- add optional `data_dir` parameter to all insert scripts defaulting to `alvys_weekly_data/<SCHEMA>`
- wire `main.run_insert` and the ingest activity to pass the client-specific data directory
- replace hard-coded JSON paths with the provided directory

## Testing
- `pip install -q -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py inserts/invoices_insert.py inserts/loads_insert.py inserts/trips_insert.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68a89bb26b648333b7e9826fd9570337