### PR TITLE
Record weekly upload completion after client inserts

### DIFF
--- a/ingest_client/__init__.py
+++ b/ingest_client/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 from main import ENTITIES, DATA_DIR, run_export, run_insert
+import db
 
 
 def main(params: Dict[str, Any]) -> str:
@@ -21,5 +22,6 @@ def main(params: Dict[str, Any]) -> str:
     logging.info("Processing %s", scac)
     run_export(scac, ENTITIES, weeks_ago=0, dry_run=False, output_dir=data_dir)
     run_insert(scac, ENTITIES, dry_run=False, data_dir=data_dir)
+    db.exec_client_upload_id(scac)
     return scac
 


### PR DESCRIPTION
## Summary
- add `db.exec_client_upload_id` to log weekly uploads per SCAC
- call new helper after ingest_client insert step
- optional `--insert-upload-id` CLI flag to invoke helper when running inserts via CLI

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68aca7cc8880833391666a451c86c088