### PR TITLE
feat: clean previous json exports

### DIFF
--- a/ingest_client/__init__.py
+++ b/ingest_client/__init__.py
@@ -20,6 +20,13 @@ def main(params: Dict[str, Any]) -> str:
     os.environ["ALVYS_CLIENT_SECRET"] = creds["client_secret"]
     os.environ["ALVYS_GRANT_TYPE"] = creds["grant_type"]
 
+    data_dir.mkdir(parents=True, exist_ok=True)
+    removed = [p for p in data_dir.glob("*.json")]
+    for json_file in removed:
+        json_file.unlink()
+    if removed:
+        logging.info("Removed %d existing JSON files from %s", len(removed), data_dir)
+
     logging.info("Processing %s", scac)
     run_export(scac, ENTITIES, weeks_ago=0, dry_run=False, output_dir=data_dir)
     run_insert(scac, ENTITIES, dry_run=False, data_dir=data_dir)


### PR DESCRIPTION
## Summary
- remove stale JSON files from a client's data directory before running export
- log cleanup step for traceability

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement azure-storage-blob)*
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py ingest_client/__init__.py`


------
https://chatgpt.com/codex/tasks/task_b_68acaa9898bc8333b7f35ff2f88065aa