### PR TITLE
Notify Logic App when functions fail

### DIFF
--- a/ingest_client/__init__.py
+++ b/ingest_client/__init__.py
@@ -4,10 +4,12 @@ import logging
 import os
 from pathlib import Path
 from typing import Dict, Any
+import traceback
 
 from main import ENTITIES, DATA_DIR, run_export, run_insert
 import db
 from utils.blob import upload_weekly_json
+from utils.alerts import send_error_notification
 
 
 def main(params: Dict[str, Any]) -> str:
@@ -15,33 +17,38 @@ def main(params: Dict[str, Any]) -> str:
     creds = params["credentials"]
     data_dir = Path(params.get("data_dir") or (DATA_DIR / scac.upper()))
 
-    os.environ["ALVYS_TENANT_ID"] = creds["tenant_id"]
-    os.environ["ALVYS_CLIENT_ID"] = creds["client_id"]
-    os.environ["ALVYS_CLIENT_SECRET"] = creds["client_secret"]
-    os.environ["ALVYS_GRANT_TYPE"] = creds["grant_type"]
-
-    data_dir.mkdir(parents=True, exist_ok=True)
-    removed = []
     try:
-        if os.access(data_dir, os.W_OK):
-            removed = list(data_dir.glob("*.json"))
-            for json_file in removed:
-                try:
-                    json_file.unlink(missing_ok=True)
-                except OSError as exc:
-                    logging.warning("Could not remove %s: %s", json_file, exc)
-        else:
-            logging.warning("Skipping JSON cleanup for read-only directory %s", data_dir)
-    except Exception as exc:
-        logging.warning("Failed to remove existing JSON files from %s: %s", data_dir, exc)
-        removed = []
-    if removed:
-        logging.info("Removed %d existing JSON files from %s", len(removed), data_dir)
+        os.environ["ALVYS_TENANT_ID"] = creds["tenant_id"]
+        os.environ["ALVYS_CLIENT_ID"] = creds["client_id"]
+        os.environ["ALVYS_CLIENT_SECRET"] = creds["client_secret"]
+        os.environ["ALVYS_GRANT_TYPE"] = creds["grant_type"]
 
-    logging.info("Processing %s", scac)
-    run_export(scac, ENTITIES, weeks_ago=0, dry_run=False, output_dir=data_dir)
-    run_insert(scac, ENTITIES, dry_run=False, data_dir=data_dir)
-    db.exec_client_upload_id(scac)
-    upload_weekly_json(scac, data_dir)
-    return scac
+        data_dir.mkdir(parents=True, exist_ok=True)
+        removed = []
+        try:
+            if os.access(data_dir, os.W_OK):
+                removed = list(data_dir.glob("*.json"))
+                for json_file in removed:
+                    try:
+                        json_file.unlink(missing_ok=True)
+                    except OSError as exc:
+                        logging.warning("Could not remove %s: %s", json_file, exc)
+            else:
+                logging.warning("Skipping JSON cleanup for read-only directory %s", data_dir)
+        except Exception as exc:
+            logging.warning("Failed to remove existing JSON files from %s: %s", data_dir, exc)
+            removed = []
+        if removed:
+            logging.info("Removed %d existing JSON files from %s", len(removed), data_dir)
+
+        logging.info("Processing %s", scac)
+        run_export(scac, ENTITIES, weeks_ago=0, dry_run=False, output_dir=data_dir)
+        run_insert(scac, ENTITIES, dry_run=False, data_dir=data_dir)
+        db.exec_client_upload_id(scac)
+        upload_weekly_json(scac, data_dir)
+        return scac
+    except Exception as err:  # pragma: no cover - notify and re-raise
+        stack = traceback.format_exc()
+        send_error_notification("ingest_client", str(err), stack)
+        raise
 

--- a/list_clients/__init__.py
+++ b/list_clients/__init__.py
@@ -1,23 +1,32 @@
 """Activity to list SCACs and credentials from dbo.ALVYS_CLIENTS."""
 from typing import List, Dict, Any
+import traceback
+
 import db
+from utils.alerts import send_error_notification
+
 
 def main(input: Any) -> List[Dict[str, str]]:
-    query = (
-        "SELECT SCAC, TENANT_ID, CLIENT_ID, CLIENT_SECRET, GRANT_TYPE "
-        "FROM dbo.ALVYS_CLIENTS"
-    )
-    with db.get_conn() as conn, conn.cursor() as cur:
-        cur.execute(query)
-        rows = cur.fetchall()
-    # return a list of dicts with consistent keys the orchestrator expects
-    return [
-        {
-            "SCAC": r[0],
-            "TENANT_ID": r[1],
-            "CLIENT_ID": r[2],
-            "CLIENT_SECRET": r[3],
-            "GRANT_TYPE": r[4],
-        }
-        for r in rows
-    ]
+    try:
+        query = (
+            "SELECT SCAC, TENANT_ID, CLIENT_ID, CLIENT_SECRET, GRANT_TYPE "
+            "FROM dbo.ALVYS_CLIENTS"
+        )
+        with db.get_conn() as conn, conn.cursor() as cur:
+            cur.execute(query)
+            rows = cur.fetchall()
+        # return a list of dicts with consistent keys the orchestrator expects
+        return [
+            {
+                "SCAC": r[0],
+                "TENANT_ID": r[1],
+                "CLIENT_ID": r[2],
+                "CLIENT_SECRET": r[3],
+                "GRANT_TYPE": r[4],
+            }
+            for r in rows
+        ]
+    except Exception as err:  # pragma: no cover - notify and re-raise
+        stack = traceback.format_exc()
+        send_error_notification("list_clients", str(err), stack)
+        raise

--- a/notify_failure/__init__.py
+++ b/notify_failure/__init__.py
@@ -1,0 +1,12 @@
+"""Activity to relay error notifications to the Logic App."""
+from typing import Dict
+
+from utils.alerts import send_error_notification
+
+
+def main(params: Dict[str, str]) -> None:
+    function_name = params.get("functionName", "unknown")
+    message = params.get("message", "")
+    stack_trace = params.get("stackTrace", "")
+    correlation_id = params.get("correlationId")
+    send_error_notification(function_name, message, stack_trace, correlation_id)

--- a/notify_failure/function.json
+++ b/notify_failure/function.json
@@ -1,0 +1,10 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "params",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ]
+}

--- a/utils/alerts.py
+++ b/utils/alerts.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Error notification utilities for Azure Functions."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+_ENDPOINT = (
+    "https://prod-168.westus.logic.azure.com:443/"
+    "workflows/c1616e65b35d40238ae046c60d5b372a/triggers/manual/paths/"
+    "invoke?api-version=2016-06-01"
+)
+
+
+def send_error_notification(
+    function_name: str,
+    message: str,
+    stack_trace: str,
+    correlation_id: Optional[str] = None,
+) -> None:
+    """POST a standardized error payload to the Logic App endpoint."""
+    payload = {
+        "status": "error",
+        "functionName": function_name,
+        "message": message,
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "details": {
+            "stackTrace": stack_trace,
+            "correlationId": correlation_id or str(uuid.uuid4()),
+        },
+    }
+    try:
+        requests.post(_ENDPOINT, json=payload, timeout=10)
+    except Exception as exc:  # pragma: no cover - best effort only
+        logging.error("Failed to send error notification: %s", exc)

--- a/weekly_ingest/__init__.py
+++ b/weekly_ingest/__init__.py
@@ -5,32 +5,45 @@ import azure.durable_functions as df
 
 from main import DATA_DIR
 
+
 def orchestrator_function(context: df.DurableOrchestrationContext):
-    # get the list of clients (SCAC + creds) via an activity (I/O outside orchestrator)
-    clients: List[Dict[str, str]] = yield context.call_activity("list_clients", None)
+    try:
+        # get the list of clients (SCAC + creds) via an activity (I/O outside orchestrator)
+        clients: List[Dict[str, str]] = yield context.call_activity("list_clients", None)
 
-    failed_entity = df.EntityId("failed_scacs", "log")
+        failed_entity = df.EntityId("failed_scacs", "log")
 
-    # Fan-out sequentially with per-client error capture (simple + durable-safe)
-    for c in clients:
-        scac = c["SCAC"]
-        creds = {
-            "tenant_id": c["TENANT_ID"],
-            "client_id": c["CLIENT_ID"],
-            "client_secret": c["CLIENT_SECRET"],
-            "grant_type": c["GRANT_TYPE"],
-        }
-        payload = {
-            "scac": scac,
-            "credentials": creds,
-            "data_dir": str(DATA_DIR / scac.upper()),
-        }
-        try:
-            yield context.call_activity("ingest_client", payload)
-        except Exception as err:  # keep going; record who failed
-            logging.error("Ingest failed for %s: %s", scac, err)
-            context.signal_entity(failed_entity, "add", scac)
+        # Fan-out sequentially with per-client error capture (simple + durable-safe)
+        for c in clients:
+            scac = c["SCAC"]
+            creds = {
+                "tenant_id": c["TENANT_ID"],
+                "client_id": c["CLIENT_ID"],
+                "client_secret": c["CLIENT_SECRET"],
+                "grant_type": c["GRANT_TYPE"],
+            }
+            payload = {
+                "scac": scac,
+                "credentials": creds,
+                "data_dir": str(DATA_DIR / scac.upper()),
+            }
+            try:
+                yield context.call_activity("ingest_client", payload)
+            except Exception as err:  # keep going; record who failed
+                logging.error("Ingest failed for %s: %s", scac, err)
+                context.signal_entity(failed_entity, "add", scac)
 
-    return "OK"
+        return "OK"
+    except Exception as err:
+        yield context.call_activity(
+            "notify_failure",
+            {
+                "functionName": "weekly_ingest",
+                "message": str(err),
+                "stackTrace": getattr(err, "stack_trace", str(err)),
+            },
+        )
+        raise
+
 
 main = df.Orchestrator.create(orchestrator_function)

--- a/weekly_ingest_start/__init__.py
+++ b/weekly_ingest_start/__init__.py
@@ -1,13 +1,21 @@
 """Timer-triggered starter for the weekly ingest orchestrator."""
 
 import logging
+import traceback
 
 import azure.durable_functions as df
 import azure.functions as func
 
+from utils.alerts import send_error_notification
+
 
 async def main(mytimer: func.TimerRequest, starter: str) -> None:
-    client = df.DurableOrchestrationClient(starter)
-    instance_id = await client.start_new("weekly_ingest")
-    logging.info("Started orchestration with ID %s", instance_id)
+    try:
+        client = df.DurableOrchestrationClient(starter)
+        instance_id = await client.start_new("weekly_ingest")
+        logging.info("Started orchestration with ID %s", instance_id)
+    except Exception as err:  # pragma: no cover - notify and re-raise
+        stack = traceback.format_exc()
+        send_error_notification("weekly_ingest_start", str(err), stack)
+        raise
 


### PR DESCRIPTION
## Summary
- post structured failure payloads to Logic App endpoint
- add utility and activity for error notifications
- wrap ingestion functions to report exceptions

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py ingest_client/__init__.py list_clients/__init__.py weekly_ingest/__init__.py weekly_ingest_start/__init__.py notify_failure/__init__.py utils/alerts.py`


------
https://chatgpt.com/codex/tasks/task_b_68acd4cda9288333b8782515a25589c3