### PR TITLE
Use env-defined Logic App endpoint and document configuration

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,6 +58,7 @@ In **Configuration -> Application settings**, add/update:
 - `ALVYS_SQL_CONN_STR=Driver={ODBC Driver 18 for SQL Server};Server=...`
 - `ALVYS_BLOB_CONN_STR=DefaultEndpointsProtocol=https;AccountName=...`
 - `ALVYS_BLOB_CONTAINER=container-name`
+- `LOGIC_APP_ENDPOINT=https://<logic-app-callback-url>?sig=...`
 
 Restart the Function App after saving.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ ALVYS_SQL_CONN_STR="DRIVER={ODBC Driver 17 for SQL Server};SERVER=server;DATABAS
 # Azure Blob Storage
 ALVYS_BLOB_CONN_STR="DefaultEndpointsProtocol=https;AccountName=..."
 ALVYS_BLOB_CONTAINER="container-name"
+
+# Logic App callback
+LOGIC_APP_ENDPOINT="https://<logic-app-callback-url>?sig=..."
 ```
 
 Place a copy of this file at the project root as `.env` and fill in the real

--- a/dev.example.env
+++ b/dev.example.env
@@ -6,3 +6,6 @@ ALVYS_GRANT_TYPE="value"
 
 # SQL Server connection string
 ALVYS_SQL_CONN_STR="DRIVER={ODBC Driver 17 for SQL Server};SERVER=server;DATABASE=db;UID=user;PWD=pwd"
+
+# Logic App callback
+LOGIC_APP_ENDPOINT="https://<logic-app-callback-url>?sig=..."

--- a/utils/alerts.py
+++ b/utils/alerts.py
@@ -4,15 +4,14 @@
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from datetime import datetime
 from typing import Optional
 
 import requests
 
-_ENDPOINT = (
-    "https://prod-168.westus.logic.azure.com:443/workflows/c1616e65b35d40238ae046c60d5b372a/triggers/manual/paths/invoke?api-version=2016-06-01"
-)
+_ENDPOINT = os.environ["LOGIC_APP_ENDPOINT"]
 
 
 def send_error_notification(
@@ -33,6 +32,7 @@ def send_error_notification(
         },
     }
     try:
-        requests.post(_ENDPOINT, json=payload, timeout=10)
+        response = requests.post(_ENDPOINT, json=payload, timeout=10)
+        response.raise_for_status()
     except Exception as exc:  # pragma: no cover - best effort only
         logging.error("Failed to send error notification: %s", exc)


### PR DESCRIPTION
## Summary
- Read Logic App callback URL from `LOGIC_APP_ENDPOINT` environment variable
- Raise for HTTP errors when sending alert notifications
- Document required `LOGIC_APP_ENDPOINT` setting for deployments and local config

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68af16645e20833382eeb7a9a9f5fabd