### PR TITLE
Use env-defined Power Automate flow endpoint and document configuration

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,6 +58,7 @@ In **Configuration -> Application settings**, add/update:
 - `ALVYS_SQL_CONN_STR=Driver={ODBC Driver 18 for SQL Server};Server=...`
 - `ALVYS_BLOB_CONN_STR=DefaultEndpointsProtocol=https;AccountName=...`
 - `ALVYS_BLOB_CONTAINER=container-name`
+- `POWER_AUTOMATE_ENDPOINT=https://<power-automate-flow-url>?sig=...`
 
 Restart the Function App after saving.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ ALVYS_SQL_CONN_STR="DRIVER={ODBC Driver 17 for SQL Server};SERVER=server;DATABAS
 # Azure Blob Storage
 ALVYS_BLOB_CONN_STR="DefaultEndpointsProtocol=https;AccountName=..."
 ALVYS_BLOB_CONTAINER="container-name"
+
+# Power Automate flow callback
+POWER_AUTOMATE_ENDPOINT="https://<power-automate-flow-url>?sig=..."
 ```
 
 Place a copy of this file at the project root as `.env` and fill in the real

--- a/dev.example.env
+++ b/dev.example.env
@@ -6,3 +6,6 @@ ALVYS_GRANT_TYPE="value"
 
 # SQL Server connection string
 ALVYS_SQL_CONN_STR="DRIVER={ODBC Driver 17 for SQL Server};SERVER=server;DATABASE=db;UID=user;PWD=pwd"
+
+# Power Automate flow callback
+POWER_AUTOMATE_ENDPOINT="https://<power-automate-flow-url>?sig=..."

--- a/notify_failure/__init__.py
+++ b/notify_failure/__init__.py
@@ -1,4 +1,4 @@
-"""Activity to relay error notifications to the Logic App."""
+"""Activity to relay error notifications to the Power Automate flow."""
 from typing import Dict
 
 from utils.alerts import send_error_notification

--- a/utils/alerts.py
+++ b/utils/alerts.py
@@ -4,15 +4,14 @@
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from datetime import datetime
 from typing import Optional
 
 import requests
 
-_ENDPOINT = (
-    "https://prod-168.westus.logic.azure.com:443/workflows/c1616e65b35d40238ae046c60d5b372a/triggers/manual/paths/invoke?api-version=2016-06-01"
-)
+_ENDPOINT = os.environ["POWER_AUTOMATE_ENDPOINT"]
 
 
 def send_error_notification(
@@ -21,7 +20,7 @@ def send_error_notification(
     stack_trace: str,
     correlation_id: Optional[str] = None,
 ) -> None:
-    """POST a standardized error payload to the Logic App endpoint."""
+    """POST a standardized error payload to the Power Automate flow endpoint."""
     payload = {
         "status": "error",
         "functionName": function_name,
@@ -33,6 +32,7 @@ def send_error_notification(
         },
     }
     try:
-        requests.post(_ENDPOINT, json=payload, timeout=10)
+        response = requests.post(_ENDPOINT, json=payload, timeout=10)
+        response.raise_for_status()
     except Exception as exc:  # pragma: no cover - best effort only
         logging.error("Failed to send error notification: %s", exc)


### PR DESCRIPTION
## Summary
- Read Power Automate flow callback URL from `POWER_AUTOMATE_ENDPOINT` environment variable
- Raise for HTTP errors when sending alert notifications
- Document required `POWER_AUTOMATE_ENDPOINT` setting for deployments and local config

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile alvys_export.py alvys_insert.py inserts/active_entities_insert.py main.py`


------
https://chatgpt.com/codex/tasks/task_b_68af16645e20833382eeb7a9a9f5fabd